### PR TITLE
Fix clickhouse insert fields

### DIFF
--- a/app/services/receiver_data_processor.rb
+++ b/app/services/receiver_data_processor.rb
@@ -92,7 +92,7 @@ class ReceiverDataProcessor
 
         if key == :rfid_hold
           entry[:string_sensor_value] = item[:rfid]
-          entry[:bool_sensor_value] = value
+          entry[:boolean_sensor_value] = value
         end
 
         results << entry


### PR DESCRIPTION
## Summary
- fix boolean sensor value field name when storing sensor data in ClickHouse

## Testing
- `bundle exec rubocop -V` *(fails: ruby 3.1.3 not installed)*