### PR TITLE
Add cycle threshold and algo fields

### DIFF
--- a/app/controllers/api/v1/devices/sensors_controller.rb
+++ b/app/controllers/api/v1/devices/sensors_controller.rb
@@ -24,6 +24,8 @@ class Api::V1::Devices::SensorsController < Api::V1::BaseController
       :threshold_active,
       :threshold_idle,
       :threshold_shutdown,
+      :cycle_threshold,
+      :algo,
       :value_factor,
       :power_factor
     ]

--- a/app/models/devices/hardware_item.rb
+++ b/app/models/devices/hardware_item.rb
@@ -17,8 +17,10 @@ class Devices::HardwareItem < ApplicationRecord
         description: sensor_type.description,
         sensor_type_id: sensor_type.id,
         threshold_active: 3,
-        threshold_idle: 2,
-        threshold_shutdown: 1
+        threshold_idle: 0,
+        threshold_shutdown: 0,
+        cycle_threshold: 0,
+        algo: :base
       )
     end
   end

--- a/app/models/devices/sensor.rb
+++ b/app/models/devices/sensor.rb
@@ -7,6 +7,8 @@ class Devices::Sensor < ApplicationRecord
   has_many :sensor_data_agg_10m, class_name: 'SensorData::Agg10m', foreign_key: :sensor_id
   has_many :sensor_data_agg_1h, class_name: 'SensorData::Agg1h', foreign_key: :sensor_id
   validates :name, presence: true
+  enum :algo, { base: 0, async: 1 }
+  validates :cycle_threshold, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 600 }
 
   validate do |item|
     if item.value_factor.present?

--- a/app/serializers/devices/sensor_serializer.rb
+++ b/app/serializers/devices/sensor_serializer.rb
@@ -5,6 +5,8 @@ class Devices::SensorSerializer
              :threshold_active,
              :threshold_idle,
              :threshold_shutdown,
+             :cycle_threshold,
+             :algo,
              :value_factor,
              :power_factor
 

--- a/db/migrate/20250414215609_init.rb
+++ b/db/migrate/20250414215609_init.rb
@@ -37,8 +37,10 @@ class Init < ActiveRecord::Migration[7.2]
       t.references :sensor_type, null: false, foreign_key: { to_table: :devices_sensor_types }, index: true
       t.references :hardware_item, null: false, foreign_key: { to_table: :devices_hardware_items }, index: true
       #t.integer :threshold_active, default: 3, null: false
-      t.integer :threshold_idle, default: 2, null: false
-      t.integer :threshold_shutdown, default: 1, null: false
+      t.integer :threshold_idle, default: 0, null: false
+      t.integer :threshold_shutdown, default: 0, null: false
+      t.integer :cycle_threshold, default: 0, null: false
+      t.integer :algo, default: 0, null: false
       t.string :value_factor
       t.string :power_factor
       t.timestamps

--- a/db/migrate/20250528100000_add_cycle_threshold_and_algo_to_devices_sensors.rb
+++ b/db/migrate/20250528100000_add_cycle_threshold_and_algo_to_devices_sensors.rb
@@ -1,0 +1,8 @@
+class AddCycleThresholdAndAlgoToDevicesSensors < ActiveRecord::Migration[7.2]
+  def change
+    add_column :devices_sensors, :cycle_threshold, :integer, default: 0, null: false
+    add_column :devices_sensors, :algo, :integer, default: 0, null: false
+    change_column_default :devices_sensors, :threshold_idle, from: 2, to: 0
+    change_column_default :devices_sensors, :threshold_shutdown, from: 1, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,8 +62,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_14_215609) do
     t.bigint "sensor_type_id", null: false
     t.bigint "hardware_item_id", null: false
     t.integer "threshold_active", default: 3, null: false
-    t.integer "threshold_idle", default: 2, null: false
-    t.integer "threshold_shutdown", default: 1, null: false
+    t.integer "threshold_idle", default: 0, null: false
+    t.integer "threshold_shutdown", default: 0, null: false
+    t.integer "cycle_threshold", default: 0, null: false
+    t.integer "algo", default: 0, null: false
     t.string "value_factor"
     t.string "power_factor"
     t.datetime "created_at", null: false


### PR DESCRIPTION
## Summary
- add `cycle_threshold` and `algo` columns to devices sensors
- update defaults for `threshold_idle` and `threshold_shutdown`
- expose new fields through models, serializers and API controllers
- update hardware item sensor creation defaults
- provide new migration

## Testing
- `bundle exec rubocop` *(fails: ruby 3.1.3 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685929d07a108323871f8ec1bfca8e33