### PR TITLE
Implement time parsing utilities with tests

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -15,4 +15,42 @@ class Api::V1::BaseController < ApplicationController
       ]
     }, status: :not_found
   end
+
+  def parse_day_times
+    from = nil
+    to = nil
+    from_now = nil
+    to_now = nil
+    now = Time.zone.now
+
+    if params[:day_time_from].present?
+      date = parse_times.first
+      from_base = Time.zone.parse(params[:day_time_from])
+      from = from_base.change(year: date.year, month: date.month, day: date.day)
+      from_now = from_base.change(year: now.year, month: now.month, day: now.day)
+    end
+
+    if params[:day_time_to].present?
+      date = parse_times.last
+      to_base = Time.zone.parse(params[:day_time_to]) + 0.999999
+      to = to_base.change(year: date.year, month: date.month, day: date.day)
+      to_now = to.change(year: now.year, month: now.month, day: now.day)
+    end
+    return if !from && !to
+    raise ActionController::ParameterMissing.new('day_time_from or day_time_to') if !from || !to
+    if from_now > to_now
+      to = to + 1.day
+      if to > Time.zone.now
+        to = to - 1.day
+      end
+    end
+    from..to
+  end
+
+  def parse_times
+    from = params[:from].present? ? Time.zone.parse(params[:from]) : nil
+    to = params[:to].present? ? Time.zone.parse(params[:to]) : nil
+    raise ActionController::ParameterMissing.new('from and to') if from.nil? || to.nil?
+    from..to
+  end
 end

--- a/test/controllers/api/v1/base_controller_test.rb
+++ b/test/controllers/api/v1/base_controller_test.rb
@@ -1,0 +1,66 @@
+require_relative '../../../test_helper'
+require 'active_support/testing/time_helpers'
+
+class BaseControllerTest < Minitest::Test
+  include ActiveSupport::Testing::TimeHelpers
+
+  class DummyController < Api::V1::BaseController
+    attr_accessor :test_params
+
+    private
+
+    def params
+      ActionController::Parameters.new(@test_params || {})
+    end
+  end
+
+  def setup
+    Time.zone = 'UTC'
+    @controller = DummyController.new
+  end
+
+  def test_parse_times_success
+    @controller.test_params = { from: '2024-01-01T00:00:00Z', to: '2024-01-02T00:00:00Z' }
+    range = @controller.send(:parse_times)
+    assert_equal Time.zone.parse('2024-01-01T00:00:00Z'), range.first
+    assert_equal Time.zone.parse('2024-01-02T00:00:00Z'), range.last
+  end
+
+  def test_parse_times_missing_param
+    @controller.test_params = { from: '2024-01-01T00:00:00Z' }
+    assert_raises(ActionController::ParameterMissing) { @controller.send(:parse_times) }
+  end
+
+  def test_parse_day_times_without_params
+    @controller.test_params = { from: '2024-01-01T00:00:00Z', to: '2024-01-02T00:00:00Z' }
+    assert_nil @controller.send(:parse_day_times)
+  end
+
+  def test_parse_day_times_with_valid_params
+    @controller.test_params = {
+      from: '2024-01-01T00:00:00Z',
+      to: '2024-01-03T00:00:00Z',
+      day_time_from: '06:00',
+      day_time_to: '18:00'
+    }
+    range = @controller.send(:parse_day_times)
+    assert_equal Time.zone.parse('2024-01-01 06:00'), range.first
+    expected = Time.zone.parse('2024-01-03 18:00') + 0.999999
+    assert_in_delta expected.to_f, range.last.to_f, 0.000001
+  end
+
+  def test_parse_day_times_cross_midnight
+    travel_to Time.zone.parse('2024-01-02 01:00') do
+      @controller.test_params = {
+        from: '2024-01-01T00:00:00Z',
+        to: '2024-01-03T00:00:00Z',
+        day_time_from: '23:00',
+        day_time_to: '05:00'
+      }
+      range = @controller.send(:parse_day_times)
+      assert_equal Time.zone.parse('2024-01-01 23:00'), range.first
+      expected = Time.zone.parse('2024-01-03 05:00') + 0.999999
+      assert_in_delta expected.to_f, range.last.to_f, 0.000001
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,13 @@
+require 'minitest/autorun'
+require 'active_support/all'
+require 'action_controller/railtie'
+require 'active_record'
+
+# Minimal ApplicationController setup for tests
+module Api; module V1; end; end
+class ApplicationController < ActionController::Base
+  include ActionController::RequestForgeryProtection
+  protect_from_forgery with: :exception
+end
+
+require_relative '../app/controllers/api/v1/base_controller'


### PR DESCRIPTION
## Summary
- add `parse_day_times` and `parse_times` helpers to API base controller
- create minimal Minitest setup
- provide tests for new helpers

## Testing
- `ruby -Itest test/controllers/api/v1/base_controller_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_68719a7c0bcc8323bdde6c5e543c12b0