### PR TITLE
Add sensor data aggregation service and tests

### DIFF
--- a/app/controllers/api/v1/devices/sensors_controller.rb
+++ b/app/controllers/api/v1/devices/sensors_controller.rb
@@ -1,6 +1,8 @@
 class Api::V1::Devices::SensorsController < Api::V1::BaseController
   include Jsonapi::Crud
 
+  before_action :set_resource, only: [:data]
+
   def resource_class
     Devices::Sensor
   end
@@ -11,6 +13,12 @@ class Api::V1::Devices::SensorsController < Api::V1::BaseController
 
   def destroy
 
+  end
+
+  def data
+    between = parse_times
+    data = SensorData.new(@resource, between, params[:capacity], params[:scalable_by])
+    render json: Devices::SensorDataSerializer.new(@resource, params: { data: data })
   end
 
   private

--- a/app/lib/sensor_data.rb
+++ b/app/lib/sensor_data.rb
@@ -1,0 +1,195 @@
+class SensorData
+  VALID_SCALABLES = ['avg', 'max', 'min', 'sum', 'diff', 'avg_no_zeros']
+  VALID_CAPACITIES = ['raw', '10s', '1m', '10m', '1h']
+
+  def initialize(sensor, between, capacity, _scalable_by = nil)
+    @sensor = sensor
+    @between = between
+    @sensor_type = @sensor.sensor_type
+    @capacity = VALID_CAPACITIES.include?(capacity) ? capacity : nil
+    @scalable_by = VALID_SCALABLES.include?(_scalable_by) ? _scalable_by : nil
+  end
+
+  def from
+    @between.first
+  end
+
+  def to
+    @between.last
+  end
+
+  def timeline
+    if @sensor_type.scalable
+      data = case capacity
+              when 'raw'
+                Devices::SensorValue.chart_data(@sensor.id, @between, 'max(value) as value, null as min_value, null as max_value')
+              when '10s'
+                SensorData::Rollup10s.chart_data(@sensor.id, @between, select)
+              when '1m'
+                SensorData::Rollup1m.chart_data(@sensor.id, @between, select)
+              when '10m'
+                SensorData::Rollup10m.chart_data(@sensor.id, @between, select)
+              when '1h'
+                SensorData::Rollup1h.chart_data(@sensor.id, @between, select)
+              end
+      prepare_data(data)
+    else
+      @sensor.sensor_data_raw.select('at, millis, value, string_value, bool_value').where(at: @between).order(:at)
+    end
+  end
+
+  def prepare_data(data)
+    if @scalable_by == 'diff' && capacity != 'raw'
+      prev_max = nil
+      data.each do |item|
+        if !prev_max.nil? && !item.max_value.nil?
+          item.value = item.max_value - prev_max
+        end
+        prev_max = item.max_value unless item.max_value.nil?
+      end
+      data
+    else
+      data
+    end
+  end
+
+  def capacity
+    return @capacity if @capacity.present?
+    period = to - from
+    case period
+    when 0..1500
+      'raw'
+    when 1500..15000
+      '10s'
+    when 15000..150000
+      '1m'
+    when 150000..1500000
+      '10m'
+    else
+      '1h'
+    end
+  end
+
+  def scalable_by
+    @scalable_by.present? ? @scalable_by : @sensor_type.scalable_by
+  end
+
+  def select
+    case scalable_by
+    when 'avg'
+      'avgMerge(avg_value_state) as value, null as min_value, null as max_value'
+    when 'max'
+      'maxMerge(max_value_state) as value, null as min_value, null as max_value '
+    when 'min'
+      'minMerge(min_value_state) as value, null as min_value, null as max_value'
+    when 'sum'
+      'sumMerge(sum_value_state) as value, null as min_value, null as max_value'
+    when 'diff'
+      'maxMerge(max_value_state) - minMerge(min_value_state) as value, minMerge(min_value_state) as min_value, maxMerge(max_value_state) as max_value'
+    end
+  end
+
+  def general
+    send("general_#{@sensor_type.general_data_method}")
+  end
+
+  private
+
+  def general_none
+    nil
+  end
+
+  def general_sum
+    where = {at: @between }
+    agg_select = 'sumMerge(sum_value_state) as sum_value'
+    res = case @between.last - @between.first
+          when 0..1500
+            @sensor.sensor_data_raw.where(where).group(:sensor_id).select('sum(value) as sum_value').order(:sensor_id).first
+          when 1500..15000
+            @sensor.sensor_data_10s.where(where).group(:sensor_id).select(agg_select).order(:sensor_id).first
+          when 15000..150000
+            @sensor.sensor_data_1m.where(where).group(:sensor_id).select(agg_select).order(:sensor_id).first
+          when 150000..1500000
+            @sensor.sensor_data_10m.where(where).group(:sensor_id).select(agg_select).order(:sensor_id).first
+          else
+            @sensor.sensor_data_1h.where(where).group(:sensor_id).select(agg_select).order(:sensor_id).first
+          end
+    { min: res&.sum_value }
+  end
+
+  def general_min_max_average
+    where = { at: @between }
+    agg_select = 'maxMerge(max_value_state) as max_value, minMerge(min_value_state) as min_value, avgMerge(avg_value_state) as avg_value'
+    res = case @between.last - @between.first
+          when 0..1500
+            @sensor.sensor_data_raw.order(:sensor_id).where(where).group(:sensor_id).select('max(value) as max_value, avg(value) as avg_value, min(value) as min_value').first
+          when 1500..15000
+            @sensor.sensor_data_10s.order(:sensor_id).where(where).group(:sensor_id).select(agg_select).first
+          when 15000..150000
+            @sensor.sensor_data_1m.order(:sensor_id).where(where).group(:sensor_id).select(agg_select).first
+          when 150000..1500000
+            @sensor.sensor_data_10m.order(:sensor_id).where(where).group(:sensor_id).select(agg_select).first
+          else
+            @sensor.sensor_data_1h.order(:sensor_id).where(where).group(:sensor_id).select(agg_select).first
+          end
+    { min: res&.min_value, max: res&.max_value, avg: res&.avg_value }
+  end
+
+  def general_min_max_diff
+    where = { at: @between }
+    agg_select = 'maxMerge(max_value_state) as max_value, minMerge(min_value_state) as min_value,  max_value - min_value as diff_value'
+    res = case @between.last - @between.first
+          when 0..1500
+            @sensor.sensor_data_raw.order(:sensor_id).where(where).group(:sensor_id).select('max(value) as max_value, min(value) as min_value, max_value - min_value as diff_value').first
+          when 1500..15000
+            @sensor.sensor_data_10s.order(:sensor_id).where(where).group(:sensor_id).select(agg_select).first
+          when 15000..150000
+            @sensor.sensor_data_1m.order(:sensor_id).where(where).group(:sensor_id).select(agg_select).first
+          when 150000..1500000
+            @sensor.sensor_data_10m.order(:sensor_id).where(where).group(:sensor_id).select(agg_select).first
+          else
+            @sensor.sensor_data_1h.order(:sensor_id).where(where).group(:sensor_id).select(agg_select).first
+          end
+    { min: res&.min_value, max: res&.max_value, avg: res&.diff_value }
+  end
+
+  def general_work_idle_times
+    work_time = @sensor.sensor_data_10s.where(at: @between).count.to_i * 10
+    res = { work_time: work_time, idle_time: all_time - work_time }
+    res[:idle_time] = 0 if res[:idle_time] < 0
+    res
+  end
+
+  def general_rfid_touch_times
+    nil
+  end
+
+  def general_rfid_hold_times
+    res = {}
+    last_rfid = nil
+    last_event = nil
+    last_event_at = nil
+    @sensor.sensor_data_raw.where(at: @between).order(:at).all.each do |event|
+      event_bool = (event.bool_value == 1)
+      res[event.string_value] = 0 if res[event.string_value].nil?
+      if last_rfid.nil? && last_event.nil?
+        res[event.string_value] += (event.at - @between.first) unless event_bool
+      else
+        res[last_rfid] += (event.at - last_event_at) if last_event
+      end
+      last_rfid = event.string_value
+      last_event = event_bool
+      last_event_at = event.at
+    end
+    res[last_rfid] += (@between.last - last_event_at) if last_event
+    res
+  end
+
+  def all_time
+    first_data_at = @sensor.sensor_data_raw.order(:at).first&.at
+    return 0 unless first_data_at.present?
+    start = @between.first > first_data_at ? @between.first : first_data_at
+    finish = @between.last > Time.now ? Time.now : @between.last
+    finish - start rescue 0
+  end
+end

--- a/app/models/concerns/chartable.rb
+++ b/app/models/concerns/chartable.rb
@@ -1,0 +1,35 @@
+module Chartable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def chart_data(sensor_id, between, select_data)
+      count = (between.last - between.first).to_i / self::INTERVAL
+      query = <<~SQL
+              SELECT
+                  at,
+                  avg(value) AS value,
+                  avg(min_value) AS min_value,
+                  avg(max_value) AS max_value
+              FROM
+              (
+                  SELECT
+                      toStartOfInterval(toDateTime(#{between.first.to_i} + number * #{self::INTERVAL}), toIntervalSecond(#{self::INTERVAL})) AS at,
+                      NULL AS value,
+                      NULL AS min_value,
+                      NULL AS max_value
+                  FROM numbers(#{count})
+                  UNION ALL
+                  SELECT
+                      toStartOfInterval(at, toIntervalSecond(#{self::INTERVAL})) AS at,
+                      #{select_data}
+                  FROM #{self.table_name}
+                  WHERE (at >= toDateTime(#{between.first.to_i})) AND (at <= toDateTime(#{between.last.to_i}))  AND (sensor_id = #{sensor_id})
+                  GROUP BY at
+        )
+              GROUP BY at
+              ORDER BY at ASC
+      SQL
+      find_by_sql(query)
+    end
+  end
+end

--- a/app/models/sensor_data/rollup_10m.rb
+++ b/app/models/sensor_data/rollup_10m.rb
@@ -1,4 +1,7 @@
 class SensorData::Rollup10m < SensorData::Base
+  include Chartable
+
   self.table_name = 'sensor_data_rollup_10m'
 
+  INTERVAL = 600
 end

--- a/app/models/sensor_data/rollup_10s.rb
+++ b/app/models/sensor_data/rollup_10s.rb
@@ -1,4 +1,7 @@
 class SensorData::Rollup10s < SensorData::Base
+  include Chartable
+
   self.table_name = 'sensor_data_rollup_10s'
 
+  INTERVAL = 10
 end

--- a/app/models/sensor_data/rollup_1h.rb
+++ b/app/models/sensor_data/rollup_1h.rb
@@ -1,4 +1,7 @@
 class SensorData::Rollup1h < SensorData::Base
+  include Chartable
+
   self.table_name = 'sensor_data_rollup_1h'
 
+  INTERVAL = 3600
 end

--- a/app/models/sensor_data/rollup_1m.rb
+++ b/app/models/sensor_data/rollup_1m.rb
@@ -1,4 +1,7 @@
 class SensorData::Rollup1m < SensorData::Base
+  include Chartable
+
   self.table_name = 'sensor_data_rollup_1m'
 
+  INTERVAL = 60
 end

--- a/app/serializers/devices/sensor_data_serializer.rb
+++ b/app/serializers/devices/sensor_data_serializer.rb
@@ -1,0 +1,31 @@
+class Devices::SensorDataSerializer
+  include JSONAPI::Serializer
+  set_type :sensor_received_data
+
+  attributes :sensor_type, :data, :general
+
+  attribute :sensor_type do |sensor|
+    Devices::SensorTypeSerializer.new(sensor.sensor_type).serializable_hash[:data][:attributes]
+  end
+
+  attribute :data do |sensor, params|
+    d = params[:data]
+    case sensor.sensor_type.data_key_name
+    when 'rfid_hold'
+      [{ at: ((d.from - 1.second).to_i * 1000) }] +
+        d.timeline.map { |row| { at: (row.at.to_i * 1000).to_i, rfid: row.string_value, v: (row.bool_value == 1 ? 'in' : 'out'), personnel_id: row.respond_to?(:personnel_id) ? row.personnel_id : nil } } +
+        [{ at: ((d.to + 1.second).to_i * 1000) }]
+    when 'rfid'
+      out = d.timeline.map { |row| { at: (row.at.to_i * 1000).to_i, rfid: row.value } }
+      [{ at: ((d.from - 1.second).to_i * 1000) }] + out + [{ at: ((d.to + 1.second).to_i * 1000) }]
+    else
+      [{ at: ((d.from - 1.second).to_i * 1000) }] +
+        d.timeline.map { |row| { at: (row.at.to_i * 1000).to_i, v: row.value } } +
+        [{ at: ((d.to + 1.second).to_i * 1000) }]
+    end
+  end
+
+  attribute :general do |sensor, params|
+    params[:data].general
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,9 @@ Rails.application.routes.draw do
         resources :hardware_items do
           put :reset_crypto, on: :member
         end
-        resources :sensors
+        resources :sensors do
+          get :data, on: :member
+        end
         resources :sensor_types
       end
       namespace :sensor_data do

--- a/test/lib/sensor_data_test.rb
+++ b/test/lib/sensor_data_test.rb
@@ -1,0 +1,85 @@
+require_relative '../test_helper'
+
+class SensorDataTest < Minitest::Test
+  DummyRelation = Struct.new(:records) do
+    def select(*) = self
+    def where(*) = self
+    def order(*) = self
+    def group(*) = self
+    def count = records.size
+    def first = records.first
+    def all = records
+  end
+
+  DummySensorType = Struct.new(:scalable, :scalable_by, :general_data_method)
+  DummySensor = Struct.new(:id, :sensor_type, :sensor_data_raw, :sensor_data_10s,
+                          :sensor_data_1m, :sensor_data_10m, :sensor_data_1h)
+
+  def setup
+    @between = Time.at(0)..Time.at(10)
+    st = DummySensorType.new(true, 'avg', 'none')
+    rel = DummyRelation.new([])
+    @sensor = DummySensor.new(1, st, rel.dup, rel.dup, rel.dup, rel.dup, rel.dup)
+  end
+
+  def test_capacity_with_param
+    sd = SensorData.new(@sensor, @between, '10s', nil)
+    assert_equal '10s', sd.capacity
+  end
+
+  def test_capacity_ranges
+    assert_equal 'raw', SensorData.new(@sensor, Time.at(0)..Time.at(1000), nil, nil).capacity
+    assert_equal '10s', SensorData.new(@sensor, Time.at(0)..Time.at(2000), nil, nil).capacity
+    assert_equal '1m', SensorData.new(@sensor, Time.at(0)..Time.at(20000), nil, nil).capacity
+    assert_equal '10m', SensorData.new(@sensor, Time.at(0)..Time.at(200000), nil, nil).capacity
+    assert_equal '1h', SensorData.new(@sensor, Time.at(0)..Time.at(2000000), nil, nil).capacity
+  end
+
+  def test_scalable_by
+    sd = SensorData.new(@sensor, @between, nil, 'max')
+    assert_equal 'max', sd.scalable_by
+    sd2 = SensorData.new(@sensor, @between, nil, nil)
+    assert_equal 'avg', sd2.scalable_by
+  end
+
+  def test_select_strings
+    sd = SensorData.new(@sensor, @between, nil, 'avg')
+    assert_match /avgMerge/, sd.select
+    sd = SensorData.new(@sensor, @between, nil, 'max')
+    assert_match /maxMerge/, sd.select
+    sd = SensorData.new(@sensor, @between, nil, 'min')
+    assert_match /minMerge/, sd.select
+    sd = SensorData.new(@sensor, @between, nil, 'sum')
+    assert_match /sumMerge/, sd.select
+    sd = SensorData.new(@sensor, @between, nil, 'diff')
+    assert_match /minMerge/, sd.select
+  end
+
+  def test_prepare_data_diff
+    items = [OpenStruct.new(max_value: 3, value: 0), OpenStruct.new(max_value: 5, value: 0)]
+    sd = SensorData.new(@sensor, @between, '10s', 'diff')
+    result = sd.prepare_data(items)
+    assert_equal 0, result[0].value
+    assert_equal 2, result[1].value
+  end
+
+  def test_timeline_capacity_paths
+    sd = SensorData.new(@sensor, @between, '10s', 'avg')
+    SensorData::Rollup10s.stub(:chart_data, ['10s']) do
+      assert_equal ['10s'], sd.timeline
+    end
+
+    sd = SensorData.new(@sensor, @between, '1m', 'avg')
+    SensorData::Rollup1m.stub(:chart_data, ['1m']) do
+      assert_equal ['1m'], sd.timeline
+    end
+  end
+
+  def test_timeline_non_scalable
+    @sensor.sensor_type.scalable = false
+    rel = DummyRelation.new([OpenStruct.new(value: 1)])
+    @sensor.sensor_data_raw = rel
+    sd = SensorData.new(@sensor, @between, 'raw', nil)
+    assert_equal rel.records, sd.timeline
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,3 +11,4 @@ class ApplicationController < ActionController::Base
 end
 
 require_relative '../app/controllers/api/v1/base_controller'
+require_relative '../app/lib/sensor_data'


### PR DESCRIPTION
## Summary
- add Chartable concern with ClickHouse query builder
- include chart support in sensor rollup models
- implement SensorData service for sensor metrics
- expose `/devices/sensors/:id/data` endpoint
- serialize aggregated sensor data
- cover SensorData logic with Minitest

## Testing
- `bundle exec rake test` *(fails: KeyError: key not found: "POSTGRES_APP_DB")*

------
https://chatgpt.com/codex/tasks/task_e_6871a3a616448323a4f78acd8dfd9ecf