### PR TITLE
Add sensor data API test and bug fixes

### DIFF
--- a/app/lib/sensor_data.rb
+++ b/app/lib/sensor_data.rb
@@ -22,7 +22,10 @@ class SensorData
     if @sensor_type.scalable
       data = case capacity
               when 'raw'
-                Devices::SensorValue.chart_data(@sensor.id, @between, 'max(value) as value, null as min_value, null as max_value')
+                @sensor.sensor_data_raw
+                      .where(at: @between)
+                      .select('at, numeric_sensor_value as value, numeric_sensor_value as min_value, numeric_sensor_value as max_value')
+                      .order(:at)
               when '10s'
                 SensorData::Rollup10s.chart_data(@sensor.id, @between, select)
               when '1m'
@@ -86,6 +89,8 @@ class SensorData
       'sumMerge(sum_value_state) as value, null as min_value, null as max_value'
     when 'diff'
       'maxMerge(max_value_state) - minMerge(min_value_state) as value, minMerge(min_value_state) as min_value, maxMerge(max_value_state) as max_value'
+    when 'avg_no_zeros'
+      'avgMergeIf(avg_value_state, max_value_state != 0) as value, null as min_value, null as max_value'
     end
   end
 

--- a/app/serializers/devices/sensor_serializer.rb
+++ b/app/serializers/devices/sensor_serializer.rb
@@ -11,5 +11,5 @@ class Devices::SensorSerializer
              :power_factor
 
   belongs_to :sensor_type
-  belongs_to :hardware_item_id
+  belongs_to :hardware_item
 end

--- a/app/services/receiver_data_processor.rb
+++ b/app/services/receiver_data_processor.rb
@@ -31,8 +31,8 @@ class ReceiverDataProcessor
   def parse_json(raw)
     return raw if raw.is_a?(Hash)
     JSON.parse(raw, symbolize_names: true)
-  # rescue JSON::ParserError
-  #   nil
+  rescue JSON::ParserError
+    nil
   end
 
   def update_device_info(data)
@@ -92,7 +92,7 @@ class ReceiverDataProcessor
 
         if key == :rfid_hold
           entry[:string_sensor_value] = item[:rfid]
-          entry[:bool_sensor_value] = value
+          entry[:boolean_sensor_value] = value
         end
 
         results << entry

--- a/test/controllers/api/v1/devices/sensors_controller_test.rb
+++ b/test/controllers/api/v1/devices/sensors_controller_test.rb
@@ -1,0 +1,93 @@
+require_relative "../../../../../config/environment"
+require_relative '../../../../test_helper'
+require 'base64'
+require 'openssl'
+require 'securerandom'
+require 'ostruct'
+
+class SensorsControllerTest < ActionDispatch::IntegrationTest
+  VALID_SCALABLES = SensorData::VALID_SCALABLES
+  VALID_CAPACITIES = SensorData::VALID_CAPACITIES
+
+  def setup
+    Time.zone = 'UTC'
+    @sensor_type = Devices::SensorType.create!(
+      name: 'Current',
+      data_key_name: 'i',
+      description: 'I',
+      scalable: true,
+      scalable_by: :avg,
+      general_data_method: :none,
+      chart_type: 0
+    )
+    @hardware_model = Devices::HardwareModel.create!(name: 'Model', description: '', sensor_types: [@sensor_type])
+    Devices::HardwareItem.skip_callback(:create, :after, :create_sensors)
+    @device = Devices::HardwareItem.create!(name: 'Device', description: '', hardware_model: @hardware_model, serial_number: 'sn-1')
+    Devices::HardwareItem.set_callback(:create, :after, :create_sensors)
+    @sensor = Devices::Sensor.create!(name: 'S', description: '', sensor_type: @sensor_type, hardware_item: @device, threshold_idle: 0, threshold_shutdown: 0, cycle_threshold: 0, algo: 0)
+    @now = Time.zone.parse('2025-07-13 16:55:00')
+    @key = SecureRandom.random_bytes(16)
+    @device.update!(aes_key: @key)
+  end
+
+  def teardown
+    SensorData::Raw.connection.execute("TRUNCATE TABLE sensor_data_raw")
+    SensorData::Raw.delete_all
+    Devices::Sensor.delete_all
+    Devices::HardwareItem.delete_all
+    Devices::HardwareModel.delete_all
+    Devices::SensorType.delete_all
+  end
+
+  def send_payload(value)
+    payload = { firmware: 'v1', model: 'Model', uptime: 1, ts: (@now.to_i * 1000), data: [{ ts: (@now.to_i * 1000), i: value }] }
+    plain = payload.to_json
+    plain_padded = plain.ljust((16 - plain.bytesize % 16) % 16 + plain.bytesize, "\0")
+    cipher = OpenSSL::Cipher::AES.new(128, :CBC)
+    cipher.encrypt
+    cipher.key = @key
+    iv = SecureRandom.random_bytes(16)
+    cipher.iv = iv
+    cipher.padding = 0
+    encrypted = cipher.update(plain_padded) + cipher.final
+    headers = {
+      'X-Device-ID' => @device.serial_number,
+      'X-Nonce' => Base64.strict_encode64(iv),
+      'CONTENT_TYPE' => 'application/octet-stream'
+    }
+    post api_v1_sensor_data_receive_path, headers: headers, params: encrypted
+    assert_response :success
+  end
+
+  def stub_rollups(value)
+    row = OpenStruct.new(at: @now, value: value, min_value: value, max_value: value)
+    SensorData::Rollup10s.stub(:chart_data, [row]) do
+      SensorData::Rollup1m.stub(:chart_data, [row]) do
+        SensorData::Rollup10m.stub(:chart_data, [row]) do
+          SensorData::Rollup1h.stub(:chart_data, [row]) do
+            yield
+          end
+        end
+      end
+    end
+  end
+
+  def test_receive_and_request_data_for_all_options
+    send_payload(5)
+    from = (@now - 1.second).iso8601
+    to = (@now + 1.second).iso8601
+
+    stub_rollups(5) do
+      VALID_CAPACITIES.each do |cap|
+        VALID_SCALABLES.each do |scal|
+          get data_api_v1_devices_sensor_path(@sensor.id), params: { from: from, to: to, capacity: cap, scalable_by: scal }
+          assert_response :success
+          body = JSON.parse(response.body)
+          data = body['data']['attributes']['data']
+          assert_equal 3, data.length
+          assert_equal 5, data[1]['v']
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- fix relation in `SensorSerializer`
- store RFID boolean sensor data in `boolean_sensor_value`
- handle JSON parsing errors
- fix raw sensor timeline query
- support `avg_no_zeros` selector
- add integration test covering sensor data receive and query for all scalable/capacity options

## Testing
- `bundle exec rails test test/controllers/api/v1/devices/sensors_controller_test.rb`
- `bundle exec rails test`

------
https://chatgpt.com/codex/tasks/task_e_6873e3db21a88323b45cb8ed0af440ef