### PR TITLE
Add pairing rejection test

### DIFF
--- a/test/controllers/api/v1/sensor_data/receiver_controller_test.rb
+++ b/test/controllers/api/v1/sensor_data/receiver_controller_test.rb
@@ -36,6 +36,17 @@ class ReceiverControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil @device.reload.aes_key
   end
 
+  def test_repeat_initialization_fails
+    key = SecureRandom.random_bytes(16)
+    @device.update!(aes_key: key)
+
+    post api_v1_sensor_data_receive_path, headers: { 'X-Device-ID' => @device.serial_number }, as: :text
+
+    assert_response :bad_request
+    assert_equal 'Nonce not found', response.body
+    assert_equal key, @device.reload.aes_key
+  end
+
   def test_encrypted_payload_is_saved
     key = SecureRandom.random_bytes(16)
     @device.update!(aes_key: key)


### PR DESCRIPTION
## Summary
- add missing test for pairing when device already has AES key

## Testing
- `bundle exec rails test`

------
https://chatgpt.com/codex/tasks/task_e_6873fb8f837083239e11563c17efadf3